### PR TITLE
Update upgrade steps for 12.0

### DIFF
--- a/upgrade-netscaler.md
+++ b/upgrade-netscaler.md
@@ -1,8 +1,8 @@
 ---
 copyright:
-  years: 1994, 2017
+  years: 1994, 2018
 
-lastupdated: "2017-11-02"
+lastupdated: "2018-06-28"
 ---
 
 {:shortdesc: .shortdesc}
@@ -13,14 +13,18 @@ lastupdated: "2017-11-02"
 **NOTE:** You must be connected to the VPN before attempting this procedure.
 
 1. Log into NetScaler Management IP.
-2. Click **Upgrade Wizard**.
-3. Click **Next**.
+2. Click **System Upgrade**.
+4. Choose **Local** from the **Choose File** drop-down list. 
 4. Download the correct upgrade file from the following location:
 
 	[NetScaler Available Versions ![External link icon](../../icons/launch-glyph.svg "External link icon")](http://downloads.softlayer.local/citrix/netscaler/){: new_window}
 
-5. On the Upload Software screen, browse to the location of the upgrade file and click **Next**.
-6. On the Manage License page, click **Next** without making changes.
-7. On the Clean-up/Reboot screen, choose either option or both and then click **Next**.
-8. Click **Next** again.
-9. The summary screen shows you the version you are upgrading to. Click **Finish** to complete the process.
+5. On the Upload Software screen, browse to the location of the upgrade file and click **Upgrade**. The firmware will upload.
+6. On the resulting System Upgrade window, you will be prompted to reboot. Click **Close**.
+7. Go back to **System**, and click **Reboot**.
+8. After the upgrade, close all browser instances and clear your computer's cache before accessing the appliance.
+
+**Note**: The user interface may differ depending on the current version of your NetScaler VPX.
+
+
+


### PR DESCRIPTION
@jbmitch @ibm-cos-help
The Citrix GUI was changed slightly in 12.0. Please help review and then pull the changes. Thank you. See also Citrix documentation: 
https://docs.citrix.com/en-us/netscaler/12/upgrade-downgrade-netscaler-appliance/upgrade-standalone-appliance.html

If you have any concerns for users who are still using 10.x, you can keep one 10.x topic and one 12.0 topic. 
